### PR TITLE
bump vivado version to 2025.2

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,14 +14,14 @@
     </project>
 
     <!-- Poky main yocto layer -->
-    <project remote="yocto"     revision="refs/tags/yocto-5.0.12"    name="poky"                path="sources/poky"/>
+    <project remote="yocto"     revision="refs/tags/yocto-5.0.13"    name="poky"                path="sources/poky"/>
 
     <!-- Library layer-->
     <project remote="yocto"     revision="refs/tags/yocto-5.0.2"                        name="meta-arm"            path="sources/meta-arm"/>
-    <project remote="yocto"     revision="af1db2042caf8021d767dce1b26c08b59b96f3d1"     name="meta-virtualization" path="sources/meta-virtualization"/>
-    <project remote="oe"        revision="e621da947048842109db1b4fd3917a02e0501aa2"     name="meta-openembedded"   path="sources/meta-openembedded"/>
-    <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.1"                   name="meta-xilinx"         path="sources/meta-xilinx" sync-s="true"/>
-    <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.1"                   name="meta-openamp"        path="sources/meta-openamp"/>
+    <project remote="yocto"     revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"     name="meta-virtualization" path="sources/meta-virtualization"/>
+    <project remote="oe"        revision="89a01c3d9ad1f8fce6aeb4dd0e694cfa28d42099"     name="meta-openembedded"   path="sources/meta-openembedded"/>
+    <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.2"                   name="meta-xilinx"         path="sources/meta-xilinx" sync-s="true"/>
+    <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.2"                   name="meta-openamp"        path="sources/meta-openamp"/>
 
 
     <!-- Distro Layer -->


### PR DESCRIPTION
# Test Result

## [PASS] Vivado PL Testest

Tested with [ZuBoardDemo_PL](https://github.com/lesterlo/ZuBoardDemo_PL) Vivado project

## [PASS] Vitis PS Test

Tested with [ZuBoardDemo_PS](https://github.com/lesterlo/ZuBoardDemo_PS) Vitis project

Test with Platform build
<img width="1464" height="111" alt="image" src="https://github.com/user-attachments/assets/d0770c46-bbb8-421f-90b0-2e006fd1beb3" />

Test with R5c0 app build
<img width="1177" height="323" alt="image" src="https://github.com/user-attachments/assets/ffcbe871-10fc-4cae-a49d-45c0e1f4e882" />


Platform build success
<img width="1092" height="433" alt="image" src="https://github.com/user-attachments/assets/7289cd72-ebf8-4e27-99b8-14367de21179" />


## [PASS] Yocto Gen-machine conf Test

<img width="902" height="347" alt="image" src="https://github.com/user-attachments/assets/8a21d7d3-4175-434e-8e88-a5f431fda3f9" />

## [PASS] Yocto build 

WIC image is generated without any error

<img width="1914" height="389" alt="image" src="https://github.com/user-attachments/assets/ff2c7b30-9b72-4d57-9c3e-4b56b552154f" />

## Deployment test

### MAC address from EEPROM

MAC address is fetched from EEPROM during boot-up

<img width="925" height="246" alt="image" src="https://github.com/user-attachments/assets/1c470700-4e37-4001-a06c-316dd83436e4" />


### [FAIL] OpenAMP

Only remoteproc0 is available. Is is due to missing RPU1 definition on the domain file, use `meta-zuboard/recipes-bsp/domainyaml/openamp-overlay-zynqmp.yaml` for workaround

<img width="837" height="115" alt="image" src="https://github.com/user-attachments/assets/25524b83-679d-4b7a-b6fd-2dadf0cc17b6" />

