### PR TITLE
Fix git clone error with git protocol

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="xilinx"    fetch="https://github.com/Xilinx"/>
-    <remote name="yocto"     fetch="git://git.yoctoproject.org"/>
-    <remote name="oe"        fetch="git://git.openembedded.org"/>
+    <remote name="yocto"     fetch="https://git.yoctoproject.org"/>
+    <remote name="oe"        fetch="https://git.openembedded.org"/>
     <remote name="lesterlo"  fetch="https://github.com/lesterlo"/>
     <remote name="openAMP"   fetch="https://github.com/OpenAMP/"/>
 


### PR DESCRIPTION
This modification fix the git clone timeout issue by changing the protocol from `git://` to `https://`

Tested and it works.

<img width="600"  alt="Screenshot 2026-04-08 at 09 08 40" src="https://github.com/user-attachments/assets/31447093-e8a3-4e65-b19a-f15826f457bf" />
