### PR TITLE
bump the yocto version to 5.0.18 and others layers

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,12 +14,12 @@
     </project>
 
     <!-- Poky main yocto layer -->
-    <project remote="yocto"     revision="refs/tags/yocto-5.0.16"    name="poky"                path="sources/poky"/>
+    <project remote="yocto"     revision="refs/tags/yocto-5.0.18"    name="poky"                path="sources/poky"/>
 
     <!-- Library layer-->
-    <project remote="yocto"     revision="refs/tags/yocto-5.0.3"                        name="meta-arm"            path="sources/meta-arm"/>
-    <project remote="yocto"     revision="3dd635f613f7299d986a8ab6bc9f584370f8ed1d"     name="meta-virtualization" path="sources/meta-virtualization"/>
-    <project remote="oe"        revision="4d3e2639dec542b58708244662d5ce36810fc510"     name="meta-openembedded"   path="sources/meta-openembedded"/>
+    <project remote="yocto"     revision="c4fd56386ee30f8b46f8e4eb1220edaf510d2ac0"     name="meta-arm"            path="sources/meta-arm"/>
+    <project remote="yocto"     revision="9d0007a369deb4a6346f5ab7a9e6d432a8ed14fe"     name="meta-virtualization" path="sources/meta-virtualization"/>
+    <project remote="oe"        revision="d8cc4e44001c7257273d290ce8c4496e93d32841"     name="meta-openembedded"   path="sources/meta-openembedded"/>
     <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.2"                   name="meta-xilinx"         path="sources/meta-xilinx" sync-s="true"/>
     <project remote="xilinx"    revision="refs/tags/xlnx-rel-v2025.2"                   name="meta-openamp"        path="sources/meta-openamp"/>
 


### PR DESCRIPTION
Yocto compile didn't have any problem

<img width="1903" height="302" alt="image" src="https://github.com/user-attachments/assets/f72d0efd-f419-4ac6-b64b-0ee545bf5aed" />



Tested the fpga and the remoteproc is working. 

<img width="952" height="542" alt="image" src="https://github.com/user-attachments/assets/cc6232a3-ee1f-48d8-a738-63be304e5150" />
